### PR TITLE
Add backticks to ReadMe code samples so they show on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ Usage
 
 Simply include this file in your project (after loading jQuery) like this:
 
-<script defer src="js/jquery.flexverticalcenter.js"></script>
+```<script defer src="js/jquery.flexverticalcenter.js"></script>```
 
 Then call the plugin on the element which needs to be vertically centered in it's parent.
 
+  ```
   <script>
   $(document).ready(function() {
     $('#element-to-be-centered').flexVerticalCenter();
   });
   </script>
+  ```
 
 This will take the parents height, the elements own height and calculate the distance the element should have from the parents top to be vertically centered. This value is applied to the top margin of the element by default.
 
@@ -32,7 +34,7 @@ You can pass an options hash to the plugin.
  - `parentSelector` - a selector representing the parent to vertically center this element within, ie. ".parent" (default: the element's immediate parent)
 
 Examples:
-
+```
   <script>
   $(document).ready(function() {
     $('#element-to-be-centered').flexVerticalCenter();
@@ -40,7 +42,7 @@ Examples:
     $('#element-to-be-centered').flexVerticalCenter({ cssAttribute: 'padding-top', parentSelector: '.parent' });
   });
   </script>
-
+```
 
 Non-jQuery version
 ------------------


### PR DESCRIPTION
Without backticks, the codesamples are ignored and not displayed on this project's GitHub page.

Now, codesamples will be shown - see screenshot below.

![screen shot 2015-05-22 at 12 54 55 pm](https://cloud.githubusercontent.com/assets/145042/7763280/d4e05384-0081-11e5-95cf-e199efc8708b.png)
